### PR TITLE
cargo build can be done offline now.  

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ $(SAFE_STR_LIB):
 	cd ext/safestringlib/ && make clean && make CC=$(CC) directories libsafestring.a
 
 clean:
-	rm -fr ./*.o src/FMI/*.o src/LISA-FMI/*.o src/*.o ext/*.o benchmarks/*.o $(TAL_LIB) $(BENCH_SMITH_WATERMAN) $(BUILD_INDEX_FOR_ONLY) $(BUILD_INDEX_WITH_RC) $(BENCH_SMEM) $(BENCH_FIXED_LEN_E2E)
+	rm -fr ./*.o src/FMI/*.o src/LISA-FMI/*.o src/*.o ext/*.o benchmarks/*.o build-lisa-hash-index bench-dp-chaining $(TAL_LIB) $(BENCH_SMITH_WATERMAN) $(BUILD_INDEX_FOR_ONLY) $(BUILD_INDEX_WITH_RC) $(BENCH_SMEM) $(BENCH_FIXED_LEN_E2E)
 	cd ext/safestringlib && make CC=$(CC) clean
 
 depend:

--- a/scripts/build-rmi.linear_spline.linear.sh
+++ b/scripts/build-rmi.linear_spline.linear.sh
@@ -21,7 +21,7 @@ cd  ext/build-rmi/learned-systems-rmi
 [ -f sorted_doubles_rmi.h ] && rm sorted_doubles_rmi.h
 [ -f sorted_doubles_rmi_data.h ] && rm sorted_doubles_rmi_data.h
 
-time cargo run --release -- $A sorted_doubles_rmi linear_spline,linear $m
+time cargo run --offline --release -- $A sorted_doubles_rmi linear_spline,linear $m
 cd ..
 
 echo "cargo done.."


### PR DESCRIPTION
We need to install dependencies before running the code. All dependencies can be install using running below command in the project folder containing Cargo.toml file.
```bash
cargo build --release
```